### PR TITLE
Add NYTimes fetch CLI for Codex solver

### DIFF
--- a/gpt_5_codex/Cargo.toml
+++ b/gpt_5_codex/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 once_cell = "1.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+ureq = { version = "2.9", default-features = false, features = ["tls"] }

--- a/gpt_5_codex/src/bin/solve_pips.rs
+++ b/gpt_5_codex/src/bin/solve_pips.rs
@@ -1,0 +1,92 @@
+use chrono::{NaiveDate, Utc};
+use pips_solver::display;
+use pips_solver::loader::nyt::{self, Difficulty, NytPuzzle};
+use pips_solver::solver;
+use std::env;
+use std::process;
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{}", err);
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    let usage = "Usage: solve-pips <YYYY-MM-DD> <easy|medium|hard|all>";
+    let date_str = args.next().ok_or_else(|| usage.to_string())?;
+    let difficulty_str = args.next().ok_or_else(|| usage.to_string())?;
+    if args.next().is_some() {
+        return Err(usage.to_string());
+    }
+
+    let date = NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
+        .map_err(|_| format!("Invalid date '{}'. Expected YYYY-MM-DD.", date_str))?;
+    let today = Utc::now().date_naive();
+    if date > today {
+        return Err(format!(
+            "Date {} is in the future (today is {}).",
+            date, today
+        ));
+    }
+
+    let difficulty_token = difficulty_str.to_ascii_lowercase();
+    if difficulty_token == "all" {
+        let puzzle = nyt::fetch_puzzle(date)?;
+        solve_all(&puzzle, date)?;
+    } else {
+        let difficulty = parse_difficulty(&difficulty_token)?;
+        let puzzle = nyt::fetch_puzzle(date)?;
+        solve_single(&puzzle, date, difficulty)?;
+    }
+    Ok(())
+}
+
+fn parse_difficulty(token: &str) -> Result<Difficulty, String> {
+    match token {
+        "easy" => Ok(Difficulty::Easy),
+        "medium" => Ok(Difficulty::Medium),
+        "hard" => Ok(Difficulty::Hard),
+        other => Err(format!(
+            "Unknown difficulty '{}'. Expected easy, medium, hard, or all.",
+            other
+        )),
+    }
+}
+
+fn solve_all(puzzle: &NytPuzzle, date: NaiveDate) -> Result<(), String> {
+    for (idx, difficulty) in Difficulty::all().iter().copied().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+        println!("== {} ({}) ==", date, difficulty.display_name());
+        solve_and_print(puzzle, date, difficulty)?;
+    }
+    Ok(())
+}
+
+fn solve_single(puzzle: &NytPuzzle, date: NaiveDate, difficulty: Difficulty) -> Result<(), String> {
+    solve_and_print(puzzle, date, difficulty)
+}
+
+fn solve_and_print(
+    puzzle: &NytPuzzle,
+    date: NaiveDate,
+    difficulty: Difficulty,
+) -> Result<(), String> {
+    let game = puzzle.game(difficulty)?;
+    println!("Solving {} {}", date, difficulty.display_name());
+    let placements = solver::solve(&game)?;
+    for (index, placement) in placements.iter().enumerate() {
+        println!("{}: {}", index + 1, placement);
+    }
+    let rendered = display::render_board(&game, &placements);
+    if !rendered.is_empty() {
+        println!("\nBoard:");
+        for line in rendered {
+            println!("{}", line);
+        }
+    }
+    Ok(())
+}

--- a/gpt_5_codex/src/display.rs
+++ b/gpt_5_codex/src/display.rs
@@ -1,0 +1,43 @@
+use crate::model;
+
+/// Render the final board with solver placements overlayed.
+pub fn render_board(game: &model::Game, placements: &[model::Placement]) -> Vec<String> {
+    let points = game.board.points();
+    if points.is_empty() {
+        return Vec::new();
+    }
+
+    let min_x = points.iter().map(|p| p.x).min().unwrap();
+    let max_x = points.iter().map(|p| p.x).max().unwrap();
+    let min_y = points.iter().map(|p| p.y).min().unwrap();
+    let max_y = points.iter().map(|p| p.y).max().unwrap();
+
+    let width = (max_x - min_x + 1) as usize;
+    let height = (max_y - min_y + 1) as usize;
+
+    let mut grid = vec![vec![' '; width]; height];
+
+    for point in points {
+        let row = (point.y - min_y) as usize;
+        let col = (point.x - min_x) as usize;
+        grid[row][col] = '#';
+    }
+
+    for placement in placements {
+        for assignment in placement.assignments() {
+            let point = assignment.point;
+            if point.x < min_x || point.x > max_x || point.y < min_y || point.y > max_y {
+                continue;
+            }
+            let row = (point.y - min_y) as usize;
+            let col = (point.x - min_x) as usize;
+            if let Some(ch) = char::from_digit(assignment.pips.value() as u32, 10) {
+                grid[row][col] = ch;
+            }
+        }
+    }
+
+    grid.into_iter()
+        .map(|row| row.into_iter().collect::<String>())
+        .collect()
+}

--- a/gpt_5_codex/src/lib.rs
+++ b/gpt_5_codex/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod display;
+pub mod loader;
+pub mod model;
+pub mod solver;

--- a/gpt_5_codex/src/loader/mod.rs
+++ b/gpt_5_codex/src/loader/mod.rs
@@ -1,3 +1,5 @@
+pub mod nyt;
+
 use crate::model::{Board, Constraint, ConstraintSet, Game, Piece, Pips, Point};
 use std::collections::HashSet;
 use std::fs::File;

--- a/gpt_5_codex/src/loader/nyt.rs
+++ b/gpt_5_codex/src/loader/nyt.rs
@@ -1,0 +1,351 @@
+use super::load_game_from_reader;
+use crate::model::Game;
+use chrono::NaiveDate;
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::env;
+use std::fmt::Write as _;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use ureq::Error as UreqError;
+
+const DEFAULT_BASE_URL: &str = "https://www.nytimes.com/svc/pips/v1";
+
+#[derive(Debug, Clone, Copy)]
+pub enum Difficulty {
+    Easy,
+    Medium,
+    Hard,
+}
+
+impl Difficulty {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Difficulty::Easy => "easy",
+            Difficulty::Medium => "medium",
+            Difficulty::Hard => "hard",
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Difficulty::Easy => "Easy",
+            Difficulty::Medium => "Medium",
+            Difficulty::Hard => "Hard",
+        }
+    }
+
+    pub fn all() -> [Difficulty; 3] {
+        [Difficulty::Easy, Difficulty::Medium, Difficulty::Hard]
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PuzzleFile {
+    easy: GameDef,
+    medium: GameDef,
+    hard: GameDef,
+}
+
+#[derive(Debug, Deserialize)]
+struct GameDef {
+    constructors: Option<String>,
+    dominoes: Vec<[u8; 2]>,
+    regions: Vec<Region>,
+    id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Region {
+    indices: Vec<[u32; 2]>,
+    #[serde(default)]
+    target: Option<u32>,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+pub struct NytPuzzle {
+    inner: PuzzleFile,
+}
+
+impl NytPuzzle {
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        let inner: PuzzleFile = serde_json::from_str(json)
+            .map_err(|err| format!("Failed to parse puzzle JSON: {}", err))?;
+        Ok(Self { inner })
+    }
+
+    pub fn game(&self, difficulty: Difficulty) -> Result<Game, String> {
+        let (def, label) = match difficulty {
+            Difficulty::Easy => (&self.inner.easy, "easy"),
+            Difficulty::Medium => (&self.inner.medium, "medium"),
+            Difficulty::Hard => (&self.inner.hard, "hard"),
+        };
+        convert_game(def, label)
+    }
+}
+
+pub fn fetch_puzzle(date: NaiveDate) -> Result<NytPuzzle, String> {
+    let json = fetch_puzzle_json(date)?;
+    NytPuzzle::from_json(&json)
+}
+
+pub fn fetch_puzzle_json(date: NaiveDate) -> Result<String, String> {
+    if let Ok(dir) = env::var("NYT_PIPS_JSON_DIR") {
+        if !dir.trim().is_empty() {
+            return read_from_directory(PathBuf::from(dir), date);
+        }
+    }
+
+    let base = env::var("NYT_PIPS_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+    fetch_from_base(base.trim(), date)
+}
+
+fn fetch_from_base(base: &str, date: NaiveDate) -> Result<String, String> {
+    if base.starts_with("file://") {
+        let path = &base["file://".len()..];
+        return read_from_directory(PathBuf::from(path), date);
+    }
+
+    let path_candidate = Path::new(base);
+    if path_candidate.is_dir() {
+        return read_from_directory(path_candidate.to_path_buf(), date);
+    }
+
+    fetch_remote(base, date)
+}
+
+fn read_from_directory(directory: PathBuf, date: NaiveDate) -> Result<String, String> {
+    let mut path = directory;
+    path.push(format!("game-{}.json", date.format("%Y-%m-%d")));
+    std::fs::read_to_string(&path)
+        .map_err(|err| format!("Failed to read {}: {}", path.display(), err))
+}
+
+fn fetch_remote(base_url: &str, date: NaiveDate) -> Result<String, String> {
+    let normalized = base_url.trim_end_matches('/');
+    let url = format!("{}/{}.json", normalized, date.format("%Y-%m-%d"));
+    match ureq::get(&url).call() {
+        Ok(response) => response
+            .into_string()
+            .map_err(|err| format!("Failed to read response from {}: {}", url, err)),
+        Err(UreqError::Status(code, _)) => {
+            Err(format!("NYTimes returned HTTP {} for {}.", code, url))
+        }
+        Err(UreqError::Transport(err)) => Err(format!("Request to {} failed: {}", url, err)),
+    }
+}
+
+fn convert_game(game: &GameDef, label: &str) -> Result<Game, String> {
+    let board_points: BTreeSet<(u32, u32)> = game
+        .regions
+        .iter()
+        .flat_map(|region| region.indices.iter().map(|idx| (idx[1], idx[0])))
+        .collect();
+
+    if board_points.is_empty() {
+        return Err(format!(
+            "Game {} ({}) has no board points defined.",
+            game.id.unwrap_or_default(),
+            label
+        ));
+    }
+
+    let min_x = board_points.iter().map(|&(x, _)| x).min().unwrap();
+    let max_x = board_points.iter().map(|&(x, _)| x).max().unwrap();
+    let min_y = board_points.iter().map(|&(_, y)| y).min().unwrap();
+    let max_y = board_points.iter().map(|&(_, y)| y).max().unwrap();
+
+    let mut output = String::new();
+
+    let id_text = game
+        .id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "unknown-id".to_string());
+    let constructors = game
+        .constructors
+        .as_deref()
+        .unwrap_or("Unknown constructor");
+    writeln!(output, "// id {} ({}) - {}", id_text, label, constructors).unwrap();
+    output.push_str("board:\n");
+    for y in min_y..=max_y {
+        for x in min_x..=max_x {
+            if board_points.contains(&(x, y)) {
+                output.push('#');
+            } else {
+                output.push(' ');
+            }
+        }
+        output.push('\n');
+    }
+    output.push('\n');
+
+    output.push_str("pieces:\n");
+    if !game.dominoes.is_empty() {
+        let pieces = game
+            .dominoes
+            .iter()
+            .map(|pair| format!("{}{}", pair[0], pair[1]))
+            .collect::<Vec<_>>()
+            .join(",");
+        writeln!(output, "{}", pieces).unwrap();
+    }
+    output.push('\n');
+
+    output.push_str("constraints:\n");
+    for region in &game.regions {
+        if region.kind == "empty" {
+            continue;
+        }
+        let mut points: Vec<(u32, u32)> =
+            region.indices.iter().map(|idx| (idx[1], idx[0])).collect();
+        points.sort_by_key(|&(x, y)| (y, x));
+
+        let mut point_repr = String::new();
+        point_repr.push('{');
+        for (idx, (x, y)) in points.iter().enumerate() {
+            if idx > 0 {
+                point_repr.push(',');
+            }
+            let _ = write!(point_repr, "({},{})", x, y);
+        }
+        point_repr.push('}');
+
+        let text = match region.kind.as_str() {
+            "equals" => format!("AllSame None {}", point_repr),
+            "unequal" => format!("AllDifferent {} {}", "{}", point_repr),
+            "sum" => {
+                let target = region
+                    .target
+                    .ok_or_else(|| format!("sum constraint missing target in {} game", label))?;
+                format!("Exactly {} {}", target, point_repr)
+            }
+            "greater" => {
+                let target = region.target.ok_or_else(|| {
+                    format!("greater constraint missing target in {} game", label)
+                })?;
+                format!("MoreThan {} {}", target, point_repr)
+            }
+            "less" => {
+                let target = region
+                    .target
+                    .ok_or_else(|| format!("less constraint missing target in {} game", label))?;
+                format!("LessThan {} {}", target, point_repr)
+            }
+            other => {
+                return Err(format!(
+                    "Unknown constraint type '{}' in {} game",
+                    other, label
+                ));
+            }
+        };
+        output.push_str(&text);
+        output.push('\n');
+    }
+    output.push('\n');
+
+    load_game_from_reader(Cursor::new(output))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Difficulty, NytPuzzle, fetch_puzzle_json};
+    use chrono::NaiveDate;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const SAMPLE_JSON: &str = r#"
+{
+  "easy": {
+    "constructors": "Unit Tester",
+    "dominoes": [[1, 2], [2, 3]],
+    "regions": [
+      {"indices": [[0, 0], [1, 0]], "target": 5, "type": "sum"},
+      {"indices": [[0, 1], [1, 1]], "type": "equals"}
+    ],
+    "id": 10
+  },
+  "medium": {
+    "constructors": null,
+    "dominoes": [[3, 4]],
+    "regions": [
+      {"indices": [[0, 0], [0, 1]], "type": "unequal"}
+    ],
+    "id": 11
+  },
+  "hard": {
+    "constructors": "Unit Tester",
+    "dominoes": [[4, 4]],
+    "regions": [
+      {"indices": [[0, 0]], "target": 4, "type": "greater"},
+      {"indices": [[1, 0]], "target": 6, "type": "less"}
+    ],
+    "id": 12
+  }
+}
+"#;
+
+    #[test]
+    fn parses_sample_puzzle() {
+        let puzzle = NytPuzzle::from_json(SAMPLE_JSON).expect("puzzle parses");
+        let easy = puzzle.game(Difficulty::Easy).expect("easy game");
+        assert_eq!(easy.pieces.len(), 2);
+        let medium = puzzle.game(Difficulty::Medium).expect("medium game");
+        assert_eq!(medium.pieces.len(), 1);
+        let hard = puzzle.game(Difficulty::Hard).expect("hard game");
+        assert_eq!(hard.pieces.len(), 1);
+    }
+
+    #[test]
+    fn fetch_prefers_json_directory_env() {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time ok")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("pips_nyt_{}", timestamp));
+        fs::create_dir(&temp_dir).expect("create temp dir");
+
+        let date = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+        let file_path = temp_dir.join("game-2025-01-01.json");
+        fs::write(&file_path, SAMPLE_JSON).expect("write sample");
+
+        let guard = EnvGuard::set("NYT_PIPS_JSON_DIR", &temp_dir);
+        let json = fetch_puzzle_json(date).expect("fetch from dir");
+        drop(guard);
+
+        fs::remove_file(&file_path).ok();
+        fs::remove_dir(&temp_dir).ok();
+        assert!(json.contains("\"easy\""));
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set<T: AsRef<std::ffi::OsStr>>(key: &'static str, value: T) -> Self {
+            let previous = std::env::var(key).ok();
+            // Safety: these tests run in process isolation, and we restore the
+            // previous value (if any) before the guard drops.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(prev) = &self.previous {
+                unsafe {
+                    std::env::set_var(self.key, prev);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+}

--- a/gpt_5_codex/src/main.rs
+++ b/gpt_5_codex/src/main.rs
@@ -1,50 +1,6 @@
-mod loader;
-mod model;
-mod solver;
-
+use pips_solver::{display, loader, solver};
 use std::env;
 use std::process;
-
-fn render_board(game: &model::Game, placements: &[model::Placement]) -> Vec<String> {
-    let points = game.board.points();
-    if points.is_empty() {
-        return Vec::new();
-    }
-
-    let min_x = points.iter().map(|p| p.x).min().unwrap();
-    let max_x = points.iter().map(|p| p.x).max().unwrap();
-    let min_y = points.iter().map(|p| p.y).min().unwrap();
-    let max_y = points.iter().map(|p| p.y).max().unwrap();
-
-    let width = (max_x - min_x + 1) as usize;
-    let height = (max_y - min_y + 1) as usize;
-
-    let mut grid = vec![vec![' '; width]; height];
-
-    for point in points {
-        let row = (point.y - min_y) as usize;
-        let col = (point.x - min_x) as usize;
-        grid[row][col] = '#';
-    }
-
-    for placement in placements {
-        for assignment in placement.assignments() {
-            let point = assignment.point;
-            if point.x < min_x || point.x > max_x || point.y < min_y || point.y > max_y {
-                continue;
-            }
-            let row = (point.y - min_y) as usize;
-            let col = (point.x - min_x) as usize;
-            if let Some(ch) = char::from_digit(assignment.pips.value() as u32, 10) {
-                grid[row][col] = ch;
-            }
-        }
-    }
-
-    grid.into_iter()
-        .map(|row| row.into_iter().collect::<String>())
-        .collect()
-}
 
 fn main() {
     if let Err(err) = run() {
@@ -67,7 +23,7 @@ fn run() -> Result<(), String> {
     for (index, placement) in placements.iter().enumerate() {
         println!("{}: {}", index + 1, placement);
     }
-    let rendered = render_board(&game, &placements);
+    let rendered = display::render_board(&game, &placements);
     if !rendered.is_empty() {
         println!("\nBoard:");
         for line in rendered {

--- a/gpt_5_codex/tests/solve_pips_cli.rs
+++ b/gpt_5_codex/tests/solve_pips_cli.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn solve_pips_uses_local_fixture_directory() {
+    let binary = env!("CARGO_BIN_EXE_solve_pips");
+    let json_dir = Path::new("../json_games");
+    assert!(
+        json_dir.is_dir(),
+        "expected fixture directory at {:?}",
+        json_dir
+    );
+
+    let output = Command::new(binary)
+        .env("NYT_PIPS_JSON_DIR", json_dir)
+        .arg("2025-10-17")
+        .arg("easy")
+        .output()
+        .expect("failed to spawn solve_pips");
+
+    assert!(
+        output.status.success(),
+        "solve_pips exited with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Solving 2025-10-17 Easy"),
+        "stdout missing solve banner:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Board:"),
+        "stdout missing board output:\n{}",
+        stdout
+    );
+}

--- a/strategy.md
+++ b/strategy.md
@@ -13,11 +13,23 @@ The game involves placing a list of dominos onto a pre-defined game board in a n
 - Load a game from a simple textual representation in a file, solve it, and output the solution to standard output.
 
 # Program Structure
-The executable should be named `pips-solver`, and it should accept a file path as an argument.
+The project provides two executables:
+
+- `pips-solver <path-to-game-file>` which accepts a file path containing a textual puzzle description, solves it, and prints the placements along with a rendered board.
+- `solve-pips <YYYY-MM-DD> <easy|medium|hard|all>` which fetches the NYTimes puzzle for the specified date, solves one or more difficulties, and prints placements plus a rendered board for each requested difficulty.
 
 The data model, game loader, and solver should all be in separate submodules.  For the data model, each struct should be defined in its own module.
 
 Unit tests should be written for each of the components based on the examples in this specification document.
+
+## NYTimes Fetch CLI
+The `solve-pips` binary augments the solver by pulling puzzles directly from the NYTimes service.
+
+- The `<YYYY-MM-DD>` date argument is parsed using the `%Y-%m-%d` format; the command rejects future dates before attempting a fetch.
+- The difficulty argument accepts `easy`, `medium`, `hard`, or `all`. When `all` is specified, the solver iterates in the order Easy, Medium, Hard, printing a banner before each solve.
+- Puzzle data is fetched from `https://www.nytimes.com/svc/pips/v1/<YYYY-MM-DD>.json` by default. If the `NYT_PIPS_JSON_DIR` environment variable is set, the CLI reads `game-<date>.json` from that directory instead. The `NYT_PIPS_BASE_URL` variable provides an alternate base URL or filesystem path when needed (tests, mirroring, etc.).
+- Fetch, parse, and load errors produce descriptive user-facing messages and terminate the command.
+- For each solved difficulty, the CLI prints numbered placements starting at 1 followed by a `Board:` section mirroring the file-based solver output.
 
 # Data Model
 The fundamental idea for the data model is to treat the board as a two-dimensional grid with non-negative integer coordinates.


### PR DESCRIPTION
## Summary
- add a `solve-pips` binary that fetches the NYTimes puzzle JSON, validates the requested date, and solves one or more difficulties
- introduce a reusable NYT loader plus shared board rendering so the file-based and fetch-based CLIs share behavior
- document the new CLI in `strategy.md` and exercise it with an integration test pointed at the local fixtures

## Testing
- cargo test
- NYT_PIPS_JSON_DIR=../json_games cargo run --bin solve_pips -- 2025-10-17 hard

Closes #1
